### PR TITLE
chore: version driven by git tag, not pyproject.toml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,12 @@ jobs:
             manylinux: auto
     steps:
       - uses: actions/checkout@v4
+      - name: Set version from tag
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i.bak "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" Cargo.toml
+          rm -f Cargo.toml.bak
       - uses: PyO3/maturin-action@v1
         with:
           command: build
@@ -59,6 +65,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set version from tag
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i.bak "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" Cargo.toml
+          rm -f Cargo.toml.bak
       - uses: PyO3/maturin-action@v1
         with:
           command: sdist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pattrie"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ipnet",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pattrie"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "maturin"
 
 [project]
 name = "pattrie"
-version = "0.1.0"
 requires-python = ">=3.12"
 description = "Fast IP prefix lookup library with Rust backend"
 license = "MIT"
 dependencies = []
+dynamic = ["version"]
 
 [tool.maturin]
 python-source = "."


### PR DESCRIPTION
Remove hardcoded version from pyproject.toml (now dynamic, read from
Cargo.toml). Publish CI extracts the git tag and writes it into
Cargo.toml before each build so wheels carry the correct version.
