### PR TITLE
chore: fix musl wheel builds: install host Python and pass explicit interpreters

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
             os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             manylinux: musllinux_1_2
-            extra_args: --zig
+            extra_args: --zig -i python3.12 python3.13 python3.14
           # Linux aarch64 — glibc (AWS Graviton, Docker on Apple Silicon)
           - name: linux-aarch64
             os: ubuntu-latest
@@ -34,7 +34,7 @@ jobs:
             os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             manylinux: musllinux_1_2
-            extra_args: --zig
+            extra_args: --zig -i python3.12 python3.13 python3.14
           # macOS universal2 — fat binary covering both Intel and Apple Silicon
           - name: macos-universal2
             os: macos-latest
@@ -49,6 +49,12 @@ jobs:
             extra_args: ''
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: |
+            3.12
+            3.13
+            3.14
       - name: Set version from tag
         shell: bash
         run: |


### PR DESCRIPTION
maturin 1.12.6 won't auto-discover glibc Python when cross-compiling to
musl. Add a setup-python step (3.12/3.13/3.14) and pass -i python3.xx
in extra_args for both musl matrix entries.
