### PR TITLE
chore: fix aarch64 glibc build: use zig instead of Docker cross-compilation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,8 @@ jobs:
           - name: linux-aarch64
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            manylinux: auto
-            extra_args: ''
+            manylinux: manylinux_2_28
+            extra_args: --zig -i python3.12 python3.13 python3.14
           # Linux aarch64 — musl (Alpine Docker on ARM)
           - name: linux-aarch64-musl
             os: ubuntu-latest
@@ -50,6 +50,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
+        if: contains(matrix.extra_args, '--zig')
         with:
           python-version: |
             3.12


### PR DESCRIPTION
The manylinux cross-compilation Docker image for aarch64 contains no
Python interpreters, so maturin always fails there. Switch linux-aarch64
to zig + manylinux_2_28 (same pattern as musl builds). Also gate the
setup-python step on zig builds to avoid polluting Docker-based builds.
