### PR TITLE
refactor: remove strict param from children() and parent()

### DIFF
--- a/pattrie/_pattrie.pyi
+++ b/pattrie/_pattrie.pyi
@@ -191,20 +191,17 @@ class Pattrie:
         """Return a list of all stored prefixes as CIDR strings."""
         ...
 
-    def children(self, prefix: NetworkKey, strict: bool = False) -> list[str]:
+    def children(self, prefix: NetworkKey) -> list[str]:
         """Return all prefixes in the trie more specific than ``prefix``.
 
         Uses longest-prefix containment: any stored prefix whose address
         range is entirely within ``prefix`` is included at any depth.
         The queried ``prefix`` itself is never included in the result.
+        Returns ``[]`` when no descendants exist or the trie is empty.
 
         Args:
             prefix: The parent prefix to query (CIDR string, ``IPv4Network``,
-                or ``IPv6Network``).
-            strict: If ``False`` (default), return descendants even if
-                ``prefix`` is not itself stored in the trie — useful for
-                querying under an aggregating or virtual prefix.
-                If ``True``, return ``[]`` when ``prefix`` is not stored.
+                or ``IPv6Network``). Host bits are zeroed before lookup.
 
         Returns:
             A list of CIDR strings for all stored prefixes contained within
@@ -225,16 +222,13 @@ class Pattrie:
             t.children("10.0.0.0/8")
             # → ["10.1.0.0/16", "10.1.1.0/24", "10.2.0.0/16"]
 
-            t.children("10.0.0.0/9")          # not stored, strict=False
+            t.children("10.0.0.0/9")   # not stored — still returns descendants
             # → ["10.1.0.0/16", "10.1.1.0/24"]
-
-            t.children("10.0.0.0/9", strict=True)   # not stored
-            # → []
             ```
         """
         ...
 
-    def parent(self, prefix: NetworkKey, strict: bool = False) -> str | None:
+    def parent(self, prefix: NetworkKey) -> str | None:
         """Return the closest covering prefix for ``prefix``.
 
         Returns the longest stored prefix that contains ``prefix`` but is not
@@ -244,16 +238,12 @@ class Pattrie:
         Args:
             prefix: The prefix to query (CIDR string, ``IPv4Network``, or
                 ``IPv6Network``). Host bits are zeroed before lookup.
-            strict: If ``False`` (default), find the covering prefix for any
-                input, even if ``prefix`` is not itself stored in the trie.
-                If ``True``, raise ``KeyError`` when ``prefix`` is not stored.
 
         Returns:
             The CIDR string of the longest stored prefix that covers
             ``prefix``, or ``None`` if no such prefix exists.
 
         Raises:
-            KeyError: If ``strict=True`` and ``prefix`` is not stored.
             ValueError: If ``prefix`` belongs to the wrong address family or
                 is malformed.
 
@@ -264,12 +254,11 @@ class Pattrie:
             t["10.1.0.0/16"] = "b"
             t["10.1.1.0/24"] = "c"
 
-            t.parent("10.1.1.0/24")               # → "10.1.0.0/16"
-            t.parent("10.1.0.0/16")               # → "10.0.0.0/8"
-            t.parent("10.0.0.0/8")                # → None
+            t.parent("10.1.1.0/24")   # → "10.1.0.0/16"
+            t.parent("10.1.0.0/16")   # → "10.0.0.0/8"
+            t.parent("10.0.0.0/8")    # → None
 
-            t.parent("10.2.0.0/16")               # → "10.0.0.0/8"  (not stored, strict=False)
-            t.parent("10.2.0.0/16", strict=True)  # → KeyError
+            t.parent("10.2.0.0/16")   # → "10.0.0.0/8"  (not stored — still works)
             ```
         """
         ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,21 +7,27 @@ use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use std::sync::{Arc, RwLock};
 use std::io::Write;
 
-/// Find the closest covering prefix (immediate parent) for `prefix` in `map`.
-/// cover_keys yields ancestors from least- to most-specific; .last() returns the
-/// most-specific ancestor in a single pass. cover_keys does not implement
-/// DoubleEndedIterator so .rev() is unavailable.
-fn find_parent<P, T>(map: &PrefixMap<P, T>, prefix: &P, strict: bool) -> PyResult<Option<String>>
+/// Find the closest covering prefix (immediate parent) for `prefix`.
+/// Uses `.last()` on cover_keys — DoubleEndedIterator is unavailable so .rev() cannot be used.
+fn find_parent<P, T>(map: &PrefixMap<P, T>, prefix: &P) -> Option<String>
 where
     P: Prefix + PartialEq + std::fmt::Display,
 {
-    if strict && !map.contains_key(prefix) {
-        return Err(PyKeyError::new_err(format!("Prefix not found: {}", prefix)));
-    }
-    Ok(map.cover_keys(prefix)
+    map.cover_keys(prefix)
         .filter(|p| *p != prefix)
         .last()
-        .map(|p| p.to_string()))
+        .map(|p| p.to_string())
+}
+
+/// Collect all stored prefixes more specific than `prefix` (self excluded).
+fn find_children<P, T>(map: &PrefixMap<P, T>, prefix: &P) -> Vec<String>
+where
+    P: Prefix + PartialEq + std::fmt::Display,
+{
+    map.children(prefix)
+        .filter(|(p, _)| *p != prefix)
+        .map(|(p, _)| p.to_string())
+        .collect()
 }
 
 enum TrieInner {
@@ -404,46 +410,28 @@ impl Pattrie {
         }
     }
 
-    #[pyo3(signature = (prefix, strict=false))]
-    fn children(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>, strict: bool) -> PyResult<Vec<String>> {
+    fn children(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
         let af_inet = self.af_inet;
         let net = parse_network_key(py, prefix, self.family, af_inet)?;
 
         let guard = self.inner.read().unwrap();
-        match (&*guard, net) {
-            (TrieInner::V4(map), IpNet::V4(v4)) => {
-                if strict && !map.contains_key(&v4) {
-                    return Ok(vec![]);
-                }
-                Ok(map.children(&v4)
-                    .filter(|(p, _)| *p != &v4)
-                    .map(|(p, _)| p.to_string())
-                    .collect())
-            }
-            (TrieInner::V6(map), IpNet::V6(v6)) => {
-                if strict && !map.contains_key(&v6) {
-                    return Ok(vec![]);
-                }
-                Ok(map.children(&v6)
-                    .filter(|(p, _)| *p != &v6)
-                    .map(|(p, _)| p.to_string())
-                    .collect())
-            }
+        Ok(match (&*guard, net) {
+            (TrieInner::V4(map), IpNet::V4(v4)) => find_children(map, &v4),
+            (TrieInner::V6(map), IpNet::V6(v6)) => find_children(map, &v6),
             _ => unreachable!(),
-        }
+        })
     }
 
-    #[pyo3(signature = (prefix, strict=false))]
-    fn parent(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>, strict: bool) -> PyResult<Option<String>> {
+    fn parent(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>) -> PyResult<Option<String>> {
         let af_inet = self.af_inet;
         let net = parse_network_key(py, prefix, self.family, af_inet)?;
 
         let guard = self.inner.read().unwrap();
-        match (&*guard, net) {
-            (TrieInner::V4(map), IpNet::V4(v4)) => find_parent(map, &v4, strict),
-            (TrieInner::V6(map), IpNet::V6(v6)) => find_parent(map, &v6, strict),
+        Ok(match (&*guard, net) {
+            (TrieInner::V4(map), IpNet::V4(v4)) => find_parent(map, &v4),
+            (TrieInner::V6(map), IpNet::V6(v6)) => find_parent(map, &v6),
             _ => unreachable!(),
-        }
+        })
     }
 
     #[pyo3(signature = (keys, default=None))]

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -803,29 +803,13 @@ def test_children_empty_no_descendants():
     assert t.children("10.1.1.0/24") == []
 
 
-def test_children_strict_false_unstored_prefix():
-    """strict=False (default) returns descendants even if prefix not stored."""
+def test_children_unstored_prefix():
+    """Returns descendants even if prefix is not itself stored."""
     t = pattrie.Pattrie()
     t["10.1.0.0/16"] = "b"
     t["10.1.1.0/24"] = "c"
-    # 10.0.0.0/9 is not stored but contains both prefixes
     result = sorted(t.children("10.0.0.0/9"))
     assert result == ["10.1.0.0/16", "10.1.1.0/24"]
-
-
-def test_children_strict_true_unstored_prefix_returns_empty():
-    """strict=True returns [] when prefix is not stored."""
-    t = pattrie.Pattrie()
-    t["10.1.0.0/16"] = "b"
-    assert t.children("10.0.0.0/9", strict=True) == []
-
-
-def test_children_strict_true_stored_prefix_returns_descendants():
-    t = pattrie.Pattrie()
-    t["10.0.0.0/8"] = "a"
-    t["10.1.0.0/16"] = "b"
-    result = t.children("10.0.0.0/8", strict=True)
-    assert sorted(result) == ["10.1.0.0/16"]
 
 
 def test_children_empty_trie():
@@ -874,32 +858,14 @@ def test_parent_returns_closest_not_distant_ancestor():
     t = pattrie.Pattrie()
     t["10.0.0.0/8"] = "a"
     t["10.1.0.0/16"] = "b"
-    # query a prefix not stored, covered by both /8 and /16
-    # must return /16 (closest), not /8 (distant ancestor)
     assert t.parent("10.1.1.0/24") == "10.1.0.0/16"
 
 
-def test_parent_strict_false_unstored_prefix():
-    """strict=False (default): find covering prefix even if input is not stored."""
+def test_parent_unstored_prefix():
+    """Find covering prefix even if input is not stored."""
     t = pattrie.Pattrie()
     t["10.0.0.0/8"] = "a"
-    # 10.2.0.0/16 is not stored but is covered by 10.0.0.0/8
     assert t.parent("10.2.0.0/16") == "10.0.0.0/8"
-
-
-def test_parent_strict_true_unstored_raises():
-    """strict=True raises KeyError when prefix is not stored."""
-    t = pattrie.Pattrie()
-    t["10.0.0.0/8"] = "a"
-    with pytest.raises(KeyError):
-        t.parent("10.2.0.0/16", strict=True)
-
-
-def test_parent_strict_true_stored_returns_parent():
-    t = pattrie.Pattrie()
-    t["10.0.0.0/8"] = "a"
-    t["10.1.0.0/16"] = "b"
-    assert t.parent("10.1.0.0/16", strict=True) == "10.0.0.0/8"
 
 
 def test_parent_no_covering_prefix_returns_none():
@@ -912,14 +878,19 @@ def test_parent_no_covering_prefix_returns_none():
 def test_parent_empty_trie():
     t = pattrie.Pattrie()
     assert t.parent("10.0.0.0/8") is None
-    with pytest.raises(KeyError):
-        t.parent("10.0.0.0/8", strict=True)
 
 
 def test_parent_wrong_family_raises():
     t = pattrie.Pattrie()
     with pytest.raises(ValueError):
         t.parent("fe80::/32")
+
+
+def test_parent_top_level_prefix_returns_none():
+    """Stored prefix with no parent returns None (not KeyError)."""
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    assert t.parent("10.0.0.0/8") is None
 
 
 def test_parent_ipv6():
@@ -930,27 +901,3 @@ def test_parent_ipv6():
     assert t.parent("fe80::/48") == "fe80::/32"
     assert t.parent("fe80::/32") == "fe80::/16"
     assert t.parent("fe80::/16") is None
-
-
-def test_parent_ipv6_strict_unstored_raises():
-    t = pattrie.Pattrie(128, socket.AF_INET6)
-    t["fe80::/16"] = "a"
-    t["fe80::/32"] = "b"
-    t["fe80::/48"] = "c"
-    with pytest.raises(KeyError):
-        t.parent("fe80::/24", strict=True)
-
-
-def test_parent_ipv6_strict_stored_with_parent():
-    t = pattrie.Pattrie(128, socket.AF_INET6)
-    t["fe80::/16"] = "a"
-    t["fe80::/32"] = "b"
-    t["fe80::/48"] = "c"
-    assert t.parent("fe80::/32", strict=True) == "fe80::/16"
-
-
-def test_parent_strict_true_top_level_prefix():
-    """strict=True, stored prefix with no parent returns None (not KeyError)."""
-    t = pattrie.Pattrie()
-    t["10.0.0.0/8"] = "a"
-    assert t.parent("10.0.0.0/8", strict=True) is None


### PR DESCRIPTION
Both methods now have a single, predictable return type:
- children() always returns list[str] (empty on miss)
- parent() always returns str | None (None on miss)

No more KeyError/strict=True/False branching for callers to handle.
The removed strict flag was purely additive complexity with no
benefit that the simpler API doesn't already provide.
