### PR TITLE
feat: add values() and items() to complete the mapping protocol

### DIFF
--- a/pattrie/_pattrie.pyi
+++ b/pattrie/_pattrie.pyi
@@ -191,6 +191,22 @@ class Pattrie:
         """Return a list of all stored prefixes as CIDR strings."""
         ...
 
+    def values(self) -> list[object]:
+        """Return a list of all stored values in trie traversal order.
+
+        Order matches ``keys()`` — the *i*-th value corresponds to the
+        *i*-th key.
+        """
+        ...
+
+    def items(self) -> list[tuple[str, object]]:
+        """Return a list of ``(prefix, value)`` pairs in trie traversal order.
+
+        Each element is a two-tuple of the CIDR prefix string and its
+        associated value, in the same order as ``keys()``.
+        """
+        ...
+
     def children(self, prefix: NetworkKey) -> list[str]:
         """Return all prefixes in the trie more specific than ``prefix``.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,24 @@ where
         .collect()
 }
 
+/// Collect all stored values in trie traversal order.
+fn collect_values<P: Prefix>(map: &PrefixMap<P, Py<PyAny>>, py: Python<'_>) -> Vec<Py<PyAny>> {
+    map.iter().map(|(_, v)| v.clone_ref(py)).collect()
+}
+
+/// Collect all stored (prefix, value) pairs as Python tuples in trie traversal order.
+fn collect_items<P>(map: &PrefixMap<P, Py<PyAny>>, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>>
+where
+    P: Prefix + std::fmt::Display,
+{
+    map.iter().map(|(p, v)| {
+        PyTuple::new(py, [
+            PyString::new(py, &p.to_string()).into_any().unbind(),
+            v.clone_ref(py),
+        ]).map(|t| t.into_any().unbind())
+    }).collect()
+}
+
 enum TrieInner {
     V4(PrefixMap<Ipv4Net, Py<PyAny>>),
     V6(PrefixMap<Ipv6Net, Py<PyAny>>),
@@ -408,6 +426,22 @@ impl Pattrie {
             TrieInner::V4(map) => map.iter().map(|(p, _)| p.to_string()).collect(),
             TrieInner::V6(map) => map.iter().map(|(p, _)| p.to_string()).collect(),
         }
+    }
+
+    fn values(&self, py: Python<'_>) -> Vec<Py<PyAny>> {
+        let guard = self.inner.read().unwrap();
+        match &*guard {
+            TrieInner::V4(map) => collect_values(map, py),
+            TrieInner::V6(map) => collect_values(map, py),
+        }
+    }
+
+    fn items(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
+        let guard = self.inner.read().unwrap();
+        Ok(match &*guard {
+            TrieInner::V4(map) => collect_items(map, py)?,
+            TrieInner::V6(map) => collect_items(map, py)?,
+        })
     }
 
     fn children(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -776,6 +776,84 @@ def test_get_many_preserves_order():
 
 
 # ---------------------------------------------------------------------------
+# values()
+# ---------------------------------------------------------------------------
+
+
+def test_values_basic():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    t["192.168.0.0/16"] = "c"
+    assert t.values() == ["a", "b", "c"]
+
+
+def test_values_empty_trie():
+    t = pattrie.Pattrie()
+    assert t.values() == []
+
+
+def test_values_order_matches_keys():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    t["192.168.0.0/16"] = "c"
+    keys = t.keys()
+    values = t.values()
+    for k, v in zip(keys, values):
+        assert t[k] == v
+
+
+def test_values_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["fe80::/16"] = "link-local"
+    t["2001:db8::/32"] = "docs"
+    vals = t.values()
+    assert len(vals) == 2
+    assert set(vals) == {"link-local", "docs"}
+
+
+# ---------------------------------------------------------------------------
+# items()
+# ---------------------------------------------------------------------------
+
+
+def test_items_basic():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    result = t.items()
+    assert result == [("10.0.0.0/8", "a"), ("10.1.0.0/16", "b")]
+
+
+def test_items_empty_trie():
+    t = pattrie.Pattrie()
+    assert t.items() == []
+
+
+def test_items_order_matches_keys():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    t["192.168.0.0/16"] = "c"
+    keys = t.keys()
+    values = t.values()
+    items = t.items()
+    assert items == list(zip(keys, values))
+
+
+def test_items_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["fe80::/16"] = "link-local"
+    t["2001:db8::/32"] = "docs"
+    items = t.items()
+    assert len(items) == 2
+    item_dict = dict(items)
+    assert item_dict["fe80::/16"] == "link-local"
+    assert item_dict["2001:db8::/32"] == "docs"
+
+
+# ---------------------------------------------------------------------------
 # children()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Add values() and items() methods mirroring Python's dict API:
- values() returns stored values in trie traversal order
- items() returns (prefix, value) tuples in trie traversal order

Both align positionally with keys(). __iter__ remains key-only,
matching both pytricia and Python dict convention.

Closes #21
