### PR TITLE
feat: add insert_many() for bulk insert with GIL release

### DIFF
--- a/pattrie/_pattrie.pyi
+++ b/pattrie/_pattrie.pyi
@@ -1,6 +1,6 @@
 import os
 import socket
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 from typing import Self, final, overload
 
@@ -63,6 +63,33 @@ class Pattrie:
         ...
     @overload
     def insert(self, addr: AddressKey, prefixlen: int, value: object) -> None: ...
+    def insert_many(self, items: Iterable[tuple[NetworkKey, object]]) -> None:
+        """Insert multiple prefixes in one call.
+
+        Accepts any iterable of ``(prefix, value)`` pairs. All keys are
+        parsed and validated before any insertion begins — if a malformed
+        prefix is encountered, ``ValueError`` is raised and the trie is
+        unchanged. Trie mutations run without the GIL for improved
+        throughput on large loads.
+
+        Args:
+            items: An iterable of ``(prefix, value)`` pairs. Each prefix
+                may be a CIDR string, ``IPv4Network``, or ``IPv6Network``.
+
+        Raises:
+            ValueError: If the trie is frozen, a prefix is malformed, or
+                a prefix length exceeds ``maxbits``.
+
+        Example:
+            ```python
+            t = Pattrie()
+            t.insert_many([
+                ("10.0.0.0/8", "rfc1918"),
+                ("192.168.0.0/16", "home"),
+            ])
+            ```
+        """
+        ...
     def __setitem__(self, key: NetworkKey, value: object, /) -> None:
         """Insert or replace a prefix using `t[prefix] = value`.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 use pyo3::exceptions::{PyKeyError, PyValueError};
 use pyo3::intern;
-use pyo3::types::{PyDict, PyList, PyString, PyTuple, PyType};
+use pyo3::types::{PyDict, PyList, PySequence, PyString, PyTuple, PyType};
 use prefix_trie::{Prefix, PrefixMap};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use std::sync::{Arc, RwLock};
@@ -51,6 +51,33 @@ where
 enum TrieInner {
     V4(PrefixMap<Ipv4Net, Py<PyAny>>),
     V6(PrefixMap<Ipv6Net, Py<PyAny>>),
+}
+
+impl TrieInner {
+    fn insert(&mut self, net: IpNet, val: Py<PyAny>) {
+        match (self, net) {
+            (TrieInner::V4(map), IpNet::V4(v4)) => { map.insert(v4, val); }
+            (TrieInner::V6(map), IpNet::V6(v6)) => { map.insert(v6, val); }
+            _ => unreachable!(),
+        }
+    }
+}
+
+fn check_mutable(frozen: bool) -> PyResult<()> {
+    if frozen {
+        return Err(PyValueError::new_err("Pattrie is frozen and cannot be modified"));
+    }
+    Ok(())
+}
+
+fn validate_prefix_len(prefix_len: u8, maxbits: u8) -> PyResult<()> {
+    if prefix_len > maxbits {
+        return Err(PyValueError::new_err(format!(
+            "Prefix length {} exceeds maxbits {}",
+            prefix_len, maxbits
+        )));
+    }
+    Ok(())
 }
 
 /// Core string parsing logic — shared by parse_key and the GIL-free path in get_many.
@@ -211,26 +238,12 @@ impl Pattrie {
     }
 
     fn __setitem__(&mut self, py: Python<'_>, key: &Bound<'_, PyAny>, value: Py<PyAny>) -> PyResult<()> {
-        if self.frozen {
-            return Err(PyValueError::new_err("Pattrie is frozen and cannot be modified"));
-        }
-        let af_inet = self.af_inet;
-        let net = parse_network_key(py, key, self.family, af_inet)?;
-
-        let prefix_len = net.prefix_len();
-        if prefix_len > self.maxbits {
-            return Err(PyValueError::new_err(format!(
-                "Prefix length {} exceeds maxbits {}",
-                prefix_len, self.maxbits
-            )));
-        }
+        check_mutable(self.frozen)?;
+        let net = parse_network_key(py, key, self.family, self.af_inet)?;
+        validate_prefix_len(net.prefix_len(), self.maxbits)?;
 
         let mut guard = self.inner.write().unwrap();
-        match (&mut *guard, net) {
-            (TrieInner::V4(map), IpNet::V4(v4)) => { map.insert(v4, value.clone_ref(py)); }
-            (TrieInner::V6(map), IpNet::V6(v6)) => { map.insert(v6, value.clone_ref(py)); }
-            _ => unreachable!(),
-        }
+        guard.insert(net, value.clone_ref(py));
         Ok(())
     }
 
@@ -338,11 +351,8 @@ impl Pattrie {
     }
 
     fn delete(&mut self, _py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<()> {
-        if self.frozen {
-            return Err(PyValueError::new_err("Pattrie is frozen and cannot be modified"));
-        }
-        let af_inet = self.af_inet;
-        let net = parse_network_key(_py, key, self.family, af_inet)?;
+        check_mutable(self.frozen)?;
+        let net = parse_network_key(_py, key, self.family, self.af_inet)?;
 
         let mut guard = self.inner.write().unwrap();
         let removed = match (&mut *guard, net) {
@@ -360,16 +370,13 @@ impl Pattrie {
 
     #[pyo3(signature = (key_or_addr, value_or_prefixlen, value=None))]
     fn insert(
-        &mut self,
+        &self,
         py: Python<'_>,
         key_or_addr: &Bound<'_, PyAny>,
         value_or_prefixlen: &Bound<'_, PyAny>,
         value: Option<Py<PyAny>>,
     ) -> PyResult<()> {
-        if self.frozen {
-            return Err(PyValueError::new_err("Pattrie is frozen and cannot be modified"));
-        }
-        let af_inet = self.af_inet;
+        check_mutable(self.frozen)?;
 
         let (net, val): (IpNet, Py<PyAny>) = if let Some(v) = value {
             // 3-arg form: insert(addr, prefixlen, value)
@@ -387,30 +394,55 @@ impl Pattrie {
                 }
             };
             let is_v4 = matches!(net, IpNet::V4(_));
-            if (self.family == af_inet) != is_v4 {
+            if (self.family == self.af_inet) != is_v4 {
                 return Err(PyValueError::new_err("Address family mismatch"));
             }
             (net, v)
         } else {
             // 2-arg form: insert(prefix, value)
-            let net = parse_network_key(py, key_or_addr, self.family, af_inet)?;
+            let net = parse_network_key(py, key_or_addr, self.family, self.af_inet)?;
             (net, value_or_prefixlen.clone().unbind())
         };
 
-        let prefix_len = net.prefix_len();
-        if prefix_len > self.maxbits {
-            return Err(PyValueError::new_err(format!(
-                "Prefix length {} exceeds maxbits {}",
-                prefix_len, self.maxbits
-            )));
-        }
+        validate_prefix_len(net.prefix_len(), self.maxbits)?;
 
         let mut guard = self.inner.write().unwrap();
-        match (&mut *guard, net) {
-            (TrieInner::V4(map), IpNet::V4(v4)) => { map.insert(v4, val); }
-            (TrieInner::V6(map), IpNet::V6(v6)) => { map.insert(v6, val); }
-            _ => unreachable!(),
+        guard.insert(net, val);
+        Ok(())
+    }
+
+    fn insert_many(&self, py: Python<'_>, items: &Bound<'_, PyAny>) -> PyResult<()> {
+        check_mutable(self.frozen)?;
+
+        let mut entries: Vec<(IpNet, Py<PyAny>)> = Vec::new();
+        for item_result in items.try_iter()? {
+            let item = item_result?;
+            let seq = item.cast::<PySequence>().map_err(|_| {
+                PyValueError::new_err("Expected (prefix, value) pair, got non-sequence")
+            })?;
+            let len = seq.len()?;
+            if len != 2 {
+                return Err(PyValueError::new_err(format!(
+                    "Expected (prefix, value) pair, got sequence of length {}",
+                    len
+                )));
+            }
+            let key = seq.get_item(0)?;
+            let value: Py<PyAny> = seq.get_item(1)?.unbind();
+            let net = parse_network_key(py, &key, self.family, self.af_inet)?;
+            validate_prefix_len(net.prefix_len(), self.maxbits)?;
+            entries.push((net, value));
         }
+
+        // Parsing above needs the GIL for PyObject access; the trie write does not.
+        let inner_arc = Arc::clone(&self.inner);
+        py.detach(move || {
+            let mut guard = inner_arc.write().unwrap();
+            for (net, val) in entries {
+                guard.insert(net, val);
+            }
+        });
+
         Ok(())
     }
 

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -776,6 +776,101 @@ def test_get_many_preserves_order():
 
 
 # ---------------------------------------------------------------------------
+# insert_many()
+# ---------------------------------------------------------------------------
+
+
+def test_insert_many_basic():
+    t = pattrie.Pattrie()
+    t.insert_many(
+        [
+            ("10.0.0.0/8", "a"),
+            ("192.168.0.0/16", "b"),
+            ("172.16.0.0/12", "c"),
+        ]
+    )
+    assert len(t) == 3
+    assert t["10.1.2.3"] == "a"
+    assert t["192.168.1.1"] == "b"
+    assert t["172.16.0.1"] == "c"
+
+
+def test_insert_many_empty():
+    t = pattrie.Pattrie()
+    t.insert_many([])
+    assert len(t) == 0
+
+
+def test_insert_many_overwrites():
+    t = pattrie.Pattrie()
+    t.insert_many(
+        [
+            ("10.0.0.0/8", "first"),
+            ("10.0.0.0/8", "second"),
+        ]
+    )
+    assert len(t) == 1
+    assert t["10.0.0.0/8"] == "second"
+
+
+def test_insert_many_bad_prefix_raises():
+    """Malformed prefix raises ValueError; the trie is unchanged."""
+    t = pattrie.Pattrie()
+    t["172.16.0.0/12"] = "pre"
+    with pytest.raises(ValueError, match="not-a-prefix"):
+        t.insert_many(
+            [
+                ("10.0.0.0/8", "a"),
+                ("not-a-prefix", "b"),
+                ("192.168.0.0/16", "c"),
+            ]
+        )
+    assert len(t) == 1
+    assert t["172.16.0.1"] == "pre"
+    assert "10.0.0.1" not in t
+    assert "192.168.0.1" not in t
+
+
+def test_insert_many_frozen_raises():
+    t = pattrie.Pattrie()
+    t.freeze()
+    with pytest.raises(ValueError):
+        t.insert_many([("10.0.0.0/8", "a")])
+
+
+def test_insert_many_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t.insert_many(
+        [
+            ("fe80::/16", "link-local"),
+            ("2001:db8::/32", "docs"),
+        ]
+    )
+    assert len(t) == 2
+    assert t["fe80::1"] == "link-local"
+    assert t["2001:db8::1"] == "docs"
+
+
+def test_insert_many_generator():
+    def gen():
+        for i in range(10):
+            yield (f"{i}.0.0.0/8", str(i))
+
+    t = pattrie.Pattrie()
+    t.insert_many(gen())
+    assert len(t) == 10
+    assert t["5.1.2.3"] == "5"
+
+
+def test_insert_many_dict_items():
+    t = pattrie.Pattrie()
+    t.insert_many({"10.0.0.0/8": "a", "192.168.0.0/16": "b"}.items())
+    assert len(t) == 2
+    assert t["10.0.0.1"] == "a"
+    assert t["192.168.0.1"] == "b"
+
+
+# ---------------------------------------------------------------------------
 # values()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Two-phase implementation for improved throughput on large table loads:
- Phase 1 (GIL held): parse all keys and validate prefixes
- Phase 2 (GIL released): bulk-insert into the trie

All parsing completes before any insertion begins, so a malformed
prefix means zero inserts happened. Accepts any iterable of
(prefix, value) pairs including generators and dict.items().

Closes #22
