### PR TITLE
feat: accept raw address bytes as keys for zero-copy lookups

### DIFF
--- a/.stubtest-allowlist
+++ b/.stubtest-allowlist
@@ -1,6 +1,7 @@
 # Type-only aliases defined in the stub; not present in the compiled extension at runtime.
 pattrie\._pattrie\.NetworkKey
 pattrie\._pattrie\.AddressKey
+pattrie\._pattrie\.RawKey
 
 # pyo3 exposes generic positional-only parameter names (key_or_addr, value_or_prefixlen).
 # The stub uses user-friendly overload names (prefix, addr, prefixlen, value).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ t.get_key("10.1.2.3")  # "10.1.0.0/16"
 t.get("192.0.2.1")     # None
 ```
 
-Keys can be strings, `ipaddress.IPv4Address`, `IPv4Network`, `IPv6Address`, or `IPv6Network`.
+Keys can be strings, `ipaddress.IPv4Address`, `IPv4Network`, `IPv6Address`, or `IPv6Network`. For packet processing, keys may also be raw address bytes — a `bytes`/`bytearray`/`memoryview` of length 4 (IPv4) or 16 (IPv6), or a `(bytes, prefixlen)` tuple — e.g. `t[socket.inet_pton(socket.AF_INET, "10.1.2.3")]` or `t.get((raw, 8))`. This avoids the string formatting and re-parsing round-trip when the address is already available as bytes.
 
 ### IPv6
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ t.get_key("10.1.2.3")  # "10.1.0.0/16"
 t.get("192.0.2.1")     # None
 ```
 
-Keys can be strings, `ipaddress.IPv4Address`, `IPv4Network`, `IPv6Address`, or `IPv6Network`.
+Keys can be strings, `ipaddress.IPv4Address`, `IPv4Network`, `IPv6Address`, or `IPv6Network`. For packet processing, keys may also be raw address bytes — a `bytes`/`bytearray`/`memoryview` of length 4 (IPv4) or 16 (IPv6), or a `(bytes, prefixlen)` tuple — e.g. `t[socket.inet_pton(socket.AF_INET, "10.1.2.3")]` or `t.get((raw, 8))`. This avoids the string formatting and re-parsing round-trip when the address is already available as bytes.
 
 ## IPv6
 

--- a/pattrie/_pattrie.pyi
+++ b/pattrie/_pattrie.pyi
@@ -6,8 +6,9 @@ from typing import Self, final, overload
 
 __all__ = ["Pattrie"]
 
-type NetworkKey = str | IPv4Network | IPv6Network
-type AddressKey = str | int | IPv4Address | IPv6Address | IPv4Network | IPv6Network
+type RawKey = bytes | bytearray | memoryview | tuple[bytes | bytearray | memoryview, int]
+type NetworkKey = str | IPv4Network | IPv6Network | RawKey
+type AddressKey = str | int | IPv4Address | IPv6Address | IPv4Network | IPv6Network | RawKey
 
 @final
 class Pattrie:
@@ -50,8 +51,9 @@ class Pattrie:
 
         Accepts two calling conventions:
 
-        - `insert(prefix, value)` — `prefix` is a string, `IPv4Network`, or
-          `IPv6Network`. Host bits are zeroed before insertion.
+        - `insert(prefix, value)` — `prefix` is a string, `IPv4Network`,
+          `IPv6Network`, or raw address bytes (`bytes` or a
+          `(bytes, prefixlen)` tuple). Host bits are zeroed before insertion.
         - `insert(addr, prefixlen, value)` — address and prefix length given
           separately.
 
@@ -74,7 +76,9 @@ class Pattrie:
 
         Args:
             items: An iterable of ``(prefix, value)`` pairs. Each prefix
-                may be a CIDR string, ``IPv4Network``, or ``IPv6Network``.
+                may be a CIDR string, ``IPv4Network``, ``IPv6Network``, or
+                raw address bytes (``bytes`` or a ``(bytes, prefixlen)``
+                tuple).
 
         Raises:
             ValueError: If the trie is frozen, a prefix is malformed, or
@@ -108,7 +112,9 @@ class Pattrie:
 
         Args:
             key: An IP address or network prefix (string, `IPv4Address`,
-                `IPv6Address`, `IPv4Network`, or `IPv6Network`).
+                `IPv6Address`, `IPv4Network`, `IPv6Network`, or raw address
+                bytes — `bytes`/`bytearray`/`memoryview` or a
+                `(bytes, prefixlen)` tuple).
 
         Returns:
             The value for the longest matching prefix.
@@ -165,6 +171,12 @@ class Pattrie:
         When the trie is frozen, all trie traversals run without the GIL,
         enabling true parallel use from multiple threads.
 
+        Note:
+            Raw-bytes keys (`bytes`/`(bytes, prefixlen)`) are only supported
+            when the trie is *not* frozen; in frozen mode such keys are treated
+            as misses and return `default`. Use string or `ipaddress` keys for
+            frozen batch lookups.
+
         Args:
             keys: A sequence of IP addresses or network prefixes.
             default: Value to return for each miss. Defaults to `None`.
@@ -196,7 +208,8 @@ class Pattrie:
         longest-prefix semantics.
 
         Args:
-            key: A network prefix (string, `IPv4Network`, or `IPv6Network`).
+            key: A network prefix (string, `IPv4Network`, `IPv6Network`, or
+                raw address bytes — `bytes` or a `(bytes, prefixlen)` tuple).
 
         Returns:
             `True` if the exact prefix exists, `False` otherwise.
@@ -244,7 +257,9 @@ class Pattrie:
 
         Args:
             prefix: The parent prefix to query (CIDR string, ``IPv4Network``,
-                or ``IPv6Network``). Host bits are zeroed before lookup.
+                ``IPv6Network``, or raw address bytes — ``bytes`` or a
+                ``(bytes, prefixlen)`` tuple). Host bits are zeroed before
+                lookup.
 
         Returns:
             A list of CIDR strings for all stored prefixes contained within
@@ -279,8 +294,10 @@ class Pattrie:
         hierarchy. Returns ``None`` if no covering prefix exists.
 
         Args:
-            prefix: The prefix to query (CIDR string, ``IPv4Network``, or
-                ``IPv6Network``). Host bits are zeroed before lookup.
+            prefix: The prefix to query (CIDR string, ``IPv4Network``,
+                ``IPv6Network``, or raw address bytes — ``bytes`` or a
+                ``(bytes, prefixlen)`` tuple). Host bits are zeroed before
+                lookup.
 
         Returns:
             The CIDR string of the longest stored prefix that covers

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,65 @@ fn parse_key_from_str(s: &str, family: i32, af_inet: i32) -> PyResult<IpNet> {
     Ok(net)
 }
 
+/// Build an IpNet from raw network-order address bytes (4 → IPv4, 16 → IPv6)
+/// and an optional prefix length (defaults 32 / 128). Validates address family.
+///
+/// `bytes` is big-endian/network order — exactly what Ipv4Addr/Ipv6Addr::from
+/// consume, so no byteswap is applied (unlike the bare-int fast path).
+fn net_from_octets(bytes: &[u8], prefix_len: Option<u8>, family: i32, af_inet: i32) -> PyResult<IpNet> {
+    let net = match bytes.len() {
+        4 => {
+            let octets: [u8; 4] = bytes.try_into().unwrap();
+            IpNet::V4(Ipv4Net::new(std::net::Ipv4Addr::from(octets), prefix_len.unwrap_or(32))
+                .map_err(|e| PyValueError::new_err(e.to_string()))?)
+        }
+        16 => {
+            let octets: [u8; 16] = bytes.try_into().unwrap();
+            IpNet::V6(Ipv6Net::new(std::net::Ipv6Addr::from(octets), prefix_len.unwrap_or(128))
+                .map_err(|e| PyValueError::new_err(e.to_string()))?)
+        }
+        n => return Err(PyValueError::new_err(format!(
+            "Invalid raw address: expected 4 or 16 bytes, got {}", n
+        ))),
+    };
+    let is_v4 = matches!(net, IpNet::V4(_));
+    if (family == af_inet) != is_v4 {
+        return Err(PyValueError::new_err(format!(
+            "Address family mismatch: trie is {}, got {}-byte raw address",
+            if family == af_inet { "IPv4" } else { "IPv6" },
+            bytes.len()
+        )));
+    }
+    Ok(net)
+}
+
+/// Recognize raw-bytes key forms and build the corresponding `IpNet`.
+///
+/// Two forms are accepted: a `(bytes, prefixlen)` 2-tuple, or bare bytes/
+/// bytearray/memoryview (4 bytes → /32, 16 bytes → /128). Returns `None` for
+/// anything else (str, int, ipaddress objects, or a tuple whose prefixlen
+/// isn't an int) so the caller falls through to its other parse paths.
+fn parse_raw_bytes_like(
+    key: &Bound<'_, PyAny>,
+    family: i32,
+    af_inet: i32,
+) -> Option<PyResult<IpNet>> {
+    if let Ok(tup) = key.cast::<PyTuple>() {
+        if tup.len() == 2 {
+            if let Ok(raw) = tup.get_item(0).ok()?.extract::<Vec<u8>>() {
+                if let Ok(plen) = tup.get_item(1).ok()?.extract::<u8>() {
+                    return Some(net_from_octets(&raw, Some(plen), family, af_inet));
+                }
+            }
+        }
+        return None;
+    }
+    // Bare bytes/bytearray/memoryview via the buffer protocol (contiguous only;
+    // non-contiguous buffers Err and fall through).
+    let raw = key.extract::<Vec<u8>>().ok()?;
+    Some(net_from_octets(&raw, None, family, af_inet))
+}
+
 /// Parse a Python key (str or ipaddress object) into an IpNet.
 /// For bare addresses (no /len), uses /32 for IPv4 and /128 for IPv6.
 /// Validates against the trie's address family.
@@ -117,6 +176,8 @@ fn parse_key_from_str(s: &str, family: i32, af_inet: i32) -> PyResult<IpNet> {
 /// Fast paths (in order):
 ///   1. Python str   — zero-copy, no allocation.
 ///   2. ipaddress objects — extract packed bytes + optional prefixlen directly.
+///   2b. raw address bytes — (bytes, prefixlen) tuple or bare bytes/bytearray/
+///       memoryview (4 → /32, 16 → /128); skips string formatting/parsing.
 ///   3. bare int     — IPv4 address as u32 (network/big-endian byte order).
 fn parse_key(py: Python<'_>, key: &Bound<'_, PyAny>, family: i32, af_inet: i32) -> PyResult<IpNet> {
     // Fast path 1: Python str — borrow &str directly, no allocation.
@@ -154,6 +215,12 @@ fn parse_key(py: Python<'_>, key: &Bound<'_, PyAny>, family: i32, af_inet: i32) 
             }
             return Ok(net);
         }
+    }
+
+    // Fast path 2b: raw address bytes — either a (bytes, prefixlen) 2-tuple or
+    // bare bytes/bytearray/memoryview (4 bytes → /32, 16 bytes → /128).
+    if let Some(net) = parse_raw_bytes_like(key, family, af_inet) {
+        return net;
     }
 
     // Fast path 3: bare Python int → IPv4 address as u32 (network byte order).

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -871,6 +871,171 @@ def test_insert_many_dict_items():
 
 
 # ---------------------------------------------------------------------------
+# raw bytes keys (packet processing)
+# ---------------------------------------------------------------------------
+
+
+def test_raw_bytes_ipv4_bare():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "rfc1918"
+    raw = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    assert t[raw] == "rfc1918"
+
+
+def test_raw_bytes_ipv6_bare():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "docs"
+    raw = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
+    assert t[raw] == "docs"
+
+
+def test_raw_tuple_prefixlen_lookup():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "rfc1918"
+    raw = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    assert t.get((raw, 32)) == "rfc1918"
+    net = socket.inet_pton(socket.AF_INET, "10.0.0.0")
+    assert t.has_key((net, 8)) is True
+
+
+def test_raw_tuple_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "docs"
+    raw = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
+    assert t.get((raw, 128)) == "docs"
+    net = socket.inet_pton(socket.AF_INET6, "2001:db8::")
+    assert t.has_key((net, 32)) is True
+
+
+def test_raw_tuple_bytearray_and_memoryview():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    raw = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    assert t.get((bytearray(raw), 32)) == "a"
+    assert t.get((memoryview(raw), 32)) == "a"
+
+
+def test_raw_tuple_wrong_length_raises():
+    t = pattrie.Pattrie()
+    with pytest.raises(ValueError, match="expected 4 or 16 bytes"):
+        t[(b"\x01\x02", 8)] = "x"
+
+
+def test_raw_tuple_setitem_insert():
+    t = pattrie.Pattrie()
+    # Host bits set; insert path must truncate to the network.
+    raw = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    t[(raw, 8)] = "x"
+    assert t["10.255.255.255"] == "x"
+    assert t.get_key("10.1.2.3") == "10.0.0.0/8"
+
+
+def test_raw_bytearray_key():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    raw = bytearray(socket.inet_pton(socket.AF_INET, "10.1.2.3"))
+    assert t[raw] == "a"
+
+
+def test_raw_memoryview_key():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    raw = memoryview(socket.inet_pton(socket.AF_INET, "10.1.2.3"))
+    assert t[raw] == "a"
+
+
+def test_raw_wrong_length_raises():
+    t = pattrie.Pattrie()
+    with pytest.raises(ValueError, match="expected 4 or 16 bytes"):
+        _ = t[b"\x01\x02"]
+
+
+def test_raw_wrong_family_raises():
+    t4 = pattrie.Pattrie()
+    raw6 = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
+    with pytest.raises(ValueError, match="Address family mismatch"):
+        _ = t4[raw6]
+
+    t6 = pattrie.Pattrie(128, socket.AF_INET6)
+    raw4 = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    with pytest.raises(ValueError, match="Address family mismatch"):
+        _ = t6[raw4]
+
+
+def test_raw_tuple_prefixlen_out_of_range():
+    t = pattrie.Pattrie()
+    raw = socket.inet_pton(socket.AF_INET, "10.0.0.0")
+    with pytest.raises(ValueError):
+        t[(raw, 33)] = "x"
+
+
+def test_raw_via_contains():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    hit = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    miss = socket.inet_pton(socket.AF_INET, "192.0.2.1")
+    assert hit in t
+    assert miss not in t
+
+
+def test_raw_via_delete():
+    t = pattrie.Pattrie()
+    net = socket.inet_pton(socket.AF_INET, "10.0.0.0")
+    t[(net, 8)] = "a"
+    del t[(net, 8)]
+    assert t.has_key((net, 8)) is False
+    with pytest.raises(KeyError):
+        del t[(net, 8)]
+
+
+def test_raw_via_children():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    t["10.1.2.0/24"] = "c"
+    net = socket.inet_pton(socket.AF_INET, "10.0.0.0")
+    assert set(t.children((net, 8))) == {"10.1.0.0/16", "10.1.2.0/24"}
+
+
+def test_raw_via_get_many_unfrozen():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["192.168.0.0/16"] = "b"
+    raw = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    net = socket.inet_pton(socket.AF_INET, "192.168.0.0")
+    keys = [raw, (net, 16), "172.16.0.1", b"\x01\x02"]
+    assert t.get_many(keys, default="miss") == ["a", "b", "miss", "miss"]
+
+
+def test_raw_get_many_frozen_unsupported():
+    # Raw-bytes keys are intentionally unsupported in frozen get_many; they
+    # are treated as misses rather than raising.
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t.freeze()
+    raw = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    assert t.get_many([raw, "10.1.2.3"], default="miss") == ["miss", "a"]
+
+
+def test_raw_via_insert_many():
+    t = pattrie.Pattrie()
+    net = socket.inet_pton(socket.AF_INET, "10.0.0.0")
+    raw = socket.inet_pton(socket.AF_INET, "192.168.1.1")
+    # Outer item is (key, value); the raw tuple is the key element.
+    t.insert_many([((net, 8), "a"), (raw, "b")])
+    assert t["10.1.2.3"] == "a"
+    assert t["192.168.1.1"] == "b"
+
+
+def test_raw_tuple_non_int_prefixlen_falls_through():
+    # (bytes, non-int) must fall through to the str() fallback, not the raw
+    # path, so it raises a parse error rather than succeeding.
+    t = pattrie.Pattrie()
+    with pytest.raises(ValueError):
+        _ = t[(b"\x0a\x00\x00\x00", "8")]  # ty: ignore[invalid-argument-type]
+
+
+# ---------------------------------------------------------------------------
 # values()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Add a "raw mode" key form so callers in packet-processing pipelines can
look up prefixes using the address bytes they already have, instead of
formatting them into a string just to have Rust parse it back into bytes.

Accepted key forms (in addition to the existing string, ipaddress, and
int forms):

- a bare bytes/bytearray/memoryview of length 4 (IPv4, /32) or 16
(IPv6, /128)
- a (bytes, prefixlen) 2-tuple for an explicit prefix length

The bytes are network/big-endian, exactly what Ipv4Addr/Ipv6Addr::from
consume, so no conversion or allocation happens on the hot path.

This is implemented as two new fast paths in parse_key, so every key-
accepting method (lookup, insert, delete, contains, children/parent,
insert_many, and non-frozen get_many) gains raw-bytes support with no
per-method changes. The change is purely additive: the new paths only
fire for key types that fail to parse today, so all existing key forms
behave identically.

Frozen get_many is intentionally left unchanged and does not support
raw-bytes keys (it re-parses keys as strings under GIL release); such
keys are treated as misses there. This limitation is documented on the
method.

Closes #23
