### PR TITLE
test: address review feedback on frozen get_many raw-bytes support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ impl TrieInner {
 enum FrozenKey {
     Str(String),
     Raw(Vec<u8>, Option<u8>),
-    Invalid,
 }
 
 fn check_mutable(frozen: bool) -> PyResult<()> {
@@ -591,20 +590,19 @@ impl Pattrie {
         let mut results: Vec<Py<PyAny>> = Vec::with_capacity(n);
 
         if self.frozen {
-            // Phase 1: extract all keys into owned FrozenKey while holding the GIL.
+            // Phase 1: extract all keys into owned Option<FrozenKey> while holding the GIL.
             // Order: PyString first (zero-copy), raw bytes second (must precede str() fallback
             // or bytes repr would stringify to e.g. "b'\\n\\x01\\x02\\x03'" and be lost),
-            // then str() fallback for ipaddress objects, ints, etc.
-            let mut frozen_keys: Vec<FrozenKey> = Vec::with_capacity(n);
+            // then str() fallback for ipaddress objects, ints, etc. None for anything invalid.
+            let mut frozen_keys: Vec<Option<FrozenKey>> = Vec::with_capacity(n);
             for item in keys.iter() {
                 let fk = if let Ok(py_str) = item.cast::<PyString>() {
-                    py_str.to_str().map(|s| FrozenKey::Str(s.to_owned()))
-                        .unwrap_or(FrozenKey::Invalid)
+                    py_str.to_str().map(|s| FrozenKey::Str(s.to_owned())).ok()
                 } else if let Some((raw, plen)) = extract_raw_bytes_like(&item) {
-                    FrozenKey::Raw(raw, plen)
+                    Some(FrozenKey::Raw(raw, plen))
                 } else {
                     item.str().and_then(|ps| ps.to_str().map(|s| s.to_owned()))
-                        .map(FrozenKey::Str).unwrap_or(FrozenKey::Invalid)
+                        .map(FrozenKey::Str).ok()
                 };
                 frozen_keys.push(fk);
             }
@@ -617,10 +615,10 @@ impl Pattrie {
             let matched: Vec<Option<IpNet>> = py.detach(|| {
                 let guard = inner_arc.read().unwrap();
                 frozen_keys.iter().map(|fk| {
+                    let fk = fk.as_ref()?;
                     let net = match fk {
                         FrozenKey::Str(s) => parse_key_from_str(s, family, af_inet).ok()?,
                         FrozenKey::Raw(raw, plen) => net_from_octets(raw, *plen, family, af_inet).ok()?,
-                        FrozenKey::Invalid => return None,
                     };
                     match (&*guard, &net) {
                         (TrieInner::V4(map), IpNet::V4(v4)) => {

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -1031,6 +1031,70 @@ def test_raw_get_many_frozen_vs_unfrozen_parity():
     assert frozen_result == unfrozen_result
 
 
+def test_raw_get_many_non_contiguous_memoryview_is_miss():
+    """Non-contiguous memoryview falls through to a miss without raising."""
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    raw = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    non_contiguous = memoryview(raw)[::2]
+    assert t.get_many([non_contiguous], default="miss") == ["miss"]
+    t.freeze()
+    assert t.get_many([non_contiguous], default="miss") == ["miss"]
+
+
+def test_raw_get_many_non_contiguous_memoryview_ipv6_is_miss():
+    """Non-contiguous IPv6 memoryview falls through to a miss without raising."""
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "a"
+    raw = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
+    non_contiguous = memoryview(raw)[::2]
+    assert t.get_many([non_contiguous], default="miss") == ["miss"]
+    t.freeze()
+    assert t.get_many([non_contiguous], default="miss") == ["miss"]
+
+
+def test_raw_get_many_invalid_tuple_prefixlen_is_miss():
+    """(bytes, non-int/None/negative/out-of-range) tuples are treated as misses in get_many."""
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    net = socket.inet_pton(socket.AF_INET, "10.0.0.0")
+    bad_keys: list = [
+        (net, "16"),  # non-int prefixlen
+        (net, None),  # None prefixlen
+        (net, -1),  # negative prefixlen
+        (net, 33),  # just above max valid for IPv4
+        (net, 40),  # out-of-range for IPv4
+    ]
+    assert t.get_many(bad_keys, default="miss") == ["miss"] * 5
+    t.freeze()
+    assert t.get_many(bad_keys, default="miss") == ["miss"] * 5
+
+
+def test_raw_get_many_valid_tuple_prefixlen_ipv4_bounds():
+    """(bytes, 32) — max valid IPv4 prefixlen — resolves correctly in both modes."""
+    t = pattrie.Pattrie()
+    t["10.0.0.0/32"] = "host"
+    net = socket.inet_pton(socket.AF_INET, "10.0.0.0")
+    assert t.get_many([(net, 32)], default="miss") == ["host"]
+    t.freeze()
+    assert t.get_many([(net, 32)], default="miss") == ["host"]
+
+
+def test_raw_get_many_frozen_vs_unfrozen_parity_ipv6():
+    """Frozen and non-frozen get_many return identical results for IPv6 raw-bytes keys."""
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "docs"
+    t["fe80::/10"] = "link-local"
+    raw = socket.inet_pton(socket.AF_INET6, "2001:db8::1")
+    net = socket.inet_pton(socket.AF_INET6, "fe80::1")
+    keys = [raw, bytearray(raw), memoryview(raw), (net, 128), "2001:db8::1", b"\x01\x02"]
+
+    unfrozen_result = t.get_many(keys, default="miss")
+    t.freeze()
+    frozen_result = t.get_many(keys, default="miss")
+    assert frozen_result == unfrozen_result
+
+
 def test_raw_via_insert_many():
     t = pattrie.Pattrie()
     net = socket.inet_pton(socket.AF_INET, "10.0.0.0")


### PR DESCRIPTION
Replace FrozenKey::Invalid with Option<FrozenKey> (Vec<Option<FrozenKey>>
in Phase 1, fk.as_ref()? in Phase 2) to eliminate the bespoke Invalid
state and reduce branching.

Add three tests: non-contiguous memoryview is a miss without raising;
(bytes, non-int/None/out-of-range) tuples are misses in both frozen and
unfrozen get_many; IPv6 frozen-vs-unfrozen parity mirrors the IPv4 version.