### PR TITLE
feat: add get_all() — full covering-prefix chain lookup

### DIFF
--- a/pattrie/_pattrie.pyi
+++ b/pattrie/_pattrie.pyi
@@ -282,6 +282,47 @@ class Pattrie:
         """
         ...
 
+    def get_all(self, key: AddressKey) -> list[tuple[str, object]]:
+        """Return all covering prefixes for ``key``, most-specific first.
+
+        Walks the full longest-prefix-match chain and returns every stored
+        prefix that covers ``key``, ordered from most specific (longest
+        prefix length) to least specific (shortest prefix length). Returns
+        an empty list when no prefix in the trie covers ``key``.
+
+        Args:
+            key: An IP address or network prefix (string, ``IPv4Address``,
+                ``IPv6Address``, ``IPv4Network``, ``IPv6Network``, raw
+                address bytes — ``bytes``/``bytearray``/``memoryview`` or a
+                ``(bytes, prefixlen)`` tuple).
+
+        Returns:
+            A list of ``(prefix, value)`` tuples in most-specific-first
+            order.
+
+        Raises:
+            ValueError: If ``key`` belongs to the wrong address family or
+                is malformed.
+
+        Example:
+            ```python
+            t = Pattrie()
+            t["0.0.0.0/0"] = "default"
+            t["10.0.0.0/8"] = "rfc1918"
+            t["10.1.0.0/16"] = "internal"
+
+            t.get_all("10.1.2.3")
+            # → [("10.1.0.0/16", "internal"), ("10.0.0.0/8", "rfc1918"), ("0.0.0.0/0", "default")]
+
+            t.get_all("192.168.0.1")
+            # → [("0.0.0.0/0", "default")]
+
+            t.get_all("1.2.3.4")   # no covering prefix
+            # → []
+            ```
+        """
+        ...
+
     def parent(self, prefix: NetworkKey) -> str | None:
         """Return the closest covering prefix for ``prefix``.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,30 @@ where
     }).collect()
 }
 
+/// Collect all stored (prefix, value) covering pairs for `prefix`,
+/// most-specific first (reversed cover_keys order).
+fn collect_covering_items<P>(
+    map: &PrefixMap<P, Py<PyAny>>,
+    prefix: &P,
+    py: Python<'_>,
+) -> PyResult<Vec<Py<PyAny>>>
+where
+    P: Prefix + std::fmt::Display,
+{
+    // cover_keys yields from least-specific to most-specific; collect then reverse.
+    let pairs: Vec<(&P, &Py<PyAny>)> = map
+        .cover_keys(prefix)
+        .filter_map(|p| map.get(p).map(|v| (p, v)))
+        .collect();
+
+    pairs.into_iter().rev().map(|(p, v)| {
+        PyTuple::new(py, [
+            PyString::new(py, &p.to_string()).into_any().unbind(),
+            v.clone_ref(py),
+        ]).map(|t| t.into_any().unbind())
+    }).collect()
+}
+
 enum TrieInner {
     V4(PrefixMap<Ipv4Net, Py<PyAny>>),
     V6(PrefixMap<Ipv6Net, Py<PyAny>>),
@@ -576,6 +600,18 @@ impl Pattrie {
             (TrieInner::V6(map), IpNet::V6(v6)) => find_parent(map, &v6),
             _ => unreachable!(),
         })
+    }
+
+    fn get_all(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Vec<Py<PyAny>>> {
+        let af_inet = self.af_inet;
+        let net = parse_key(py, key, self.family, af_inet)?;
+
+        let guard = self.inner.read().unwrap();
+        match (&*guard, &net) {
+            (TrieInner::V4(map), IpNet::V4(v4)) => collect_covering_items(map, v4, py),
+            (TrieInner::V6(map), IpNet::V6(v6)) => collect_covering_items(map, v6, py),
+            _ => unreachable!(),
+        }
     }
 
     #[pyo3(signature = (keys, default=None))]

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -1309,3 +1309,110 @@ def test_parent_ipv6():
     assert t.parent("fe80::/48") == "fe80::/32"
     assert t.parent("fe80::/32") == "fe80::/16"
     assert t.parent("fe80::/16") is None
+
+
+# ---------------------------------------------------------------------------
+# get_all()
+# ---------------------------------------------------------------------------
+
+
+def test_get_all_full_chain():
+    t = pattrie.Pattrie()
+    t["0.0.0.0/0"] = "default"
+    t["10.0.0.0/8"] = "rfc1918"
+    t["10.1.0.0/16"] = "internal"
+    result = t.get_all("10.1.2.3")
+    assert result == [("10.1.0.0/16", "internal"), ("10.0.0.0/8", "rfc1918"), ("0.0.0.0/0", "default")]
+
+
+def test_get_all_no_match_returns_empty():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    assert t.get_all("192.168.0.1") == []
+
+
+def test_get_all_single_covering_prefix():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    result = t.get_all("10.1.2.3")
+    assert result == [("10.0.0.0/8", "a")]
+
+
+def test_get_all_exact_match_included():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    result = t.get_all("10.1.0.0/16")
+    assert result == [("10.1.0.0/16", "b"), ("10.0.0.0/8", "a")]
+
+
+def test_get_all_host_address_key():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    assert t.get_all("10.1.2.3") == [("10.1.0.0/16", "b"), ("10.0.0.0/8", "a")]
+
+
+def test_get_all_empty_trie():
+    t = pattrie.Pattrie()
+    assert t.get_all("10.0.0.1") == []
+
+
+def test_get_all_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["fe80::/16"] = "a"
+    t["fe80::/32"] = "b"
+    t["fe80::/48"] = "c"
+    result = t.get_all("fe80::1")
+    assert result == [("fe80::/48", "c"), ("fe80::/32", "b"), ("fe80::/16", "a")]
+
+
+def test_get_all_ipv6_no_match():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["fe80::/16"] = "a"
+    assert t.get_all("2001:db8::1") == []
+
+
+def test_get_all_raw_bytes_key():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    raw = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    assert t.get_all(raw) == [("10.1.0.0/16", "b"), ("10.0.0.0/8", "a")]
+
+
+def test_get_all_wrong_family_raises():
+    t = pattrie.Pattrie()
+    with pytest.raises(ValueError):
+        t.get_all("fe80::1")
+
+
+def test_get_all_non_string_values():
+    t = pattrie.Pattrie()
+    t["0.0.0.0/0"] = None
+    t["10.0.0.0/8"] = 42
+    t["10.1.0.0/16"] = {"asn": 64512}
+    result = t.get_all("10.1.2.3")
+    assert result == [("10.1.0.0/16", {"asn": 64512}), ("10.0.0.0/8", 42), ("0.0.0.0/0", None)]
+
+
+def test_get_all_ipv4address_key():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    assert t.get_all(IPv4Address("10.1.2.3")) == [("10.1.0.0/16", "b"), ("10.0.0.0/8", "a")]
+
+
+def test_get_all_ipv4network_key():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    assert t.get_all(IPv4Network("10.1.0.0/16")) == [("10.1.0.0/16", "b"), ("10.0.0.0/8", "a")]
+
+
+def test_get_all_frozen_trie():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    t.freeze()
+    assert t.get_all("10.1.2.3") == [("10.1.0.0/16", "b"), ("10.0.0.0/8", "a")]

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -1322,7 +1322,11 @@ def test_get_all_full_chain():
     t["10.0.0.0/8"] = "rfc1918"
     t["10.1.0.0/16"] = "internal"
     result = t.get_all("10.1.2.3")
-    assert result == [("10.1.0.0/16", "internal"), ("10.0.0.0/8", "rfc1918"), ("0.0.0.0/0", "default")]
+    assert result == [
+        ("10.1.0.0/16", "internal"),
+        ("10.0.0.0/8", "rfc1918"),
+        ("0.0.0.0/0", "default"),
+    ]
 
 
 def test_get_all_no_match_returns_empty():
@@ -1408,6 +1412,43 @@ def test_get_all_ipv4network_key():
     t["10.0.0.0/8"] = "a"
     t["10.1.0.0/16"] = "b"
     assert t.get_all(IPv4Network("10.1.0.0/16")) == [("10.1.0.0/16", "b"), ("10.0.0.0/8", "a")]
+
+
+def test_get_all_ipv6address_key():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["fe80::/16"] = "a"
+    t["fe80::/32"] = "b"
+    t["fe80::/48"] = "c"
+    result = t.get_all(IPv6Address("fe80::1"))
+    assert result == [("fe80::/48", "c"), ("fe80::/32", "b"), ("fe80::/16", "a")]
+
+
+def test_get_all_ipv6network_key():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["fe80::/16"] = "a"
+    t["fe80::/32"] = "b"
+    t["fe80::/48"] = "c"
+    result = t.get_all(IPv6Network("fe80::1/128"))
+    assert result == [("fe80::/48", "c"), ("fe80::/32", "b"), ("fe80::/16", "a")]
+
+
+def test_get_all_int_key_ipv4():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    raw = socket.inet_pton(socket.AF_INET, "10.1.2.3")
+    key_int = int.from_bytes(raw, "big")
+    assert t.get_all(key_int) == [("10.1.0.0/16", "b"), ("10.0.0.0/8", "a")]
+
+
+def test_get_all_int_key_ipv6_raises():
+    # Bare int keys are IPv4-only (u32); a 128-bit int on an IPv6 trie raises ValueError.
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "a"
+    raw = socket.inet_pton(socket.AF_INET6, "2001:db8:1::1234")
+    key_int = int.from_bytes(raw, "big")
+    with pytest.raises(ValueError):
+        t.get_all(key_int)
 
 
 def test_get_all_frozen_trie():


### PR DESCRIPTION
Returns every stored prefix that covers a key, ordered most-specific
to least-specific, as a list of (prefix, value) tuples. Returns [] on
a miss. Accepts all existing key forms (string, ipaddress objects,
raw bytes, int).

Closes #38
