### PR TITLE
feat: add bare=True flag to key-emitting methods

### DIFF
--- a/pattrie/_pattrie.pyi
+++ b/pattrie/_pattrie.pyi
@@ -309,6 +309,10 @@ class Pattrie:
             Bare output is lossy — the prefix length is discarded and the
             result cannot be round-tripped back into the same prefix.
             Use this flag for display or interop, not for re-insertion.
+            Two distinct prefixes with the same network address but different
+            lengths (e.g. ``"10.0.0.0/8"`` and ``"10.0.0.0/16"``) produce
+            duplicate bare keys — building a ``dict`` from bare output will
+            silently drop all but one entry for each collision.
         """
         ...
 
@@ -335,6 +339,10 @@ class Pattrie:
             Bare output is lossy — the prefix length is discarded and the
             result cannot be round-tripped back into the same prefix.
             Use this flag for display or interop, not for re-insertion.
+            Two distinct prefixes with the same network address but different
+            lengths (e.g. ``"10.0.0.0/8"`` and ``"10.0.0.0/16"``) produce
+            duplicate bare keys — ``dict(t.items(bare=True))`` will silently
+            drop all but one entry for each collision.
         """
         ...
 

--- a/pattrie/_pattrie.pyi
+++ b/pattrie/_pattrie.pyi
@@ -189,7 +189,7 @@ class Pattrie:
         """
         ...
 
-    def get_key(self, key: AddressKey) -> str | None:
+    def get_key(self, key: AddressKey, bare: bool = False) -> str | None:
         """Return the matching prefix for a longest-prefix-match lookup.
 
         Unlike `__getitem__`, returns the *prefix string* (e.g.
@@ -197,9 +197,16 @@ class Pattrie:
 
         Args:
             key: An IP address or network prefix.
+            bare: When ``True``, strip the ``/len`` suffix and return only
+                the network address. Defaults to ``False`` (full CIDR form).
 
         Returns:
-            The matched prefix as a CIDR string, or `None` on a miss.
+            The matched prefix string, or `None` on a miss.
+
+        Note:
+            Bare output is lossy — the prefix length is discarded and the
+            result cannot be round-tripped back into the same prefix.
+            Use this flag for display or interop, not for re-insertion.
         """
         ...
 
@@ -290,8 +297,19 @@ class Pattrie:
         """
         ...
 
-    def keys(self) -> list[str]:
-        """Return a list of all stored prefixes as CIDR strings."""
+    def keys(self, bare: bool = False) -> list[str]:
+        """Return a list of all stored prefixes.
+
+        Args:
+            bare: When ``True``, strip the ``/len`` suffix and return only
+                the network address (e.g. ``"10.1.0.0"`` instead of
+                ``"10.1.0.0/24"``). Defaults to ``False`` (full CIDR form).
+
+        Note:
+            Bare output is lossy — the prefix length is discarded and the
+            result cannot be round-tripped back into the same prefix.
+            Use this flag for display or interop, not for re-insertion.
+        """
         ...
 
     def values(self) -> list[object]:
@@ -302,15 +320,25 @@ class Pattrie:
         """
         ...
 
-    def items(self) -> list[tuple[str, object]]:
+    def items(self, bare: bool = False) -> list[tuple[str, object]]:
         """Return a list of ``(prefix, value)`` pairs in trie traversal order.
 
-        Each element is a two-tuple of the CIDR prefix string and its
-        associated value, in the same order as ``keys()``.
+        Each element is a two-tuple of the prefix string and its associated
+        value, in the same order as ``keys()``.
+
+        Args:
+            bare: When ``True``, strip the ``/len`` suffix from each key,
+                returning only the network address. Defaults to ``False``
+                (full CIDR form).
+
+        Note:
+            Bare output is lossy — the prefix length is discarded and the
+            result cannot be round-tripped back into the same prefix.
+            Use this flag for display or interop, not for re-insertion.
         """
         ...
 
-    def children(self, prefix: NetworkKey) -> list[str]:
+    def children(self, prefix: NetworkKey, bare: bool = False) -> list[str]:
         """Return all prefixes in the trie more specific than ``prefix``.
 
         Uses longest-prefix containment: any stored prefix whose address
@@ -323,9 +351,12 @@ class Pattrie:
                 ``IPv6Network``, or raw address bytes — ``bytes`` or a
                 ``(bytes, prefixlen)`` tuple). Host bits are zeroed before
                 lookup.
+            bare: When ``True``, strip the ``/len`` suffix from each result,
+                returning only the network address. Defaults to ``False``
+                (full CIDR form).
 
         Returns:
-            A list of CIDR strings for all stored prefixes contained within
+            A list of prefix strings for all stored prefixes contained within
             ``prefix``. Order is lexicographic (prefix-trie traversal order).
 
         Raises:
@@ -390,7 +421,7 @@ class Pattrie:
         """
         ...
 
-    def parent(self, prefix: NetworkKey) -> str | None:
+    def parent(self, prefix: NetworkKey, bare: bool = False) -> str | None:
         """Return the closest covering prefix for ``prefix``.
 
         Returns the longest stored prefix that contains ``prefix`` but is not
@@ -402,9 +433,12 @@ class Pattrie:
                 ``IPv6Network``, or raw address bytes — ``bytes`` or a
                 ``(bytes, prefixlen)`` tuple). Host bits are zeroed before
                 lookup.
+            bare: When ``True``, strip the ``/len`` suffix from the result,
+                returning only the network address. Defaults to ``False``
+                (full CIDR form).
 
         Returns:
-            The CIDR string of the longest stored prefix that covers
+            The prefix string of the longest stored prefix that covers
             ``prefix``, or ``None`` if no such prefix exists.
 
         Raises:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,26 +7,39 @@ use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use std::sync::{Arc, RwLock};
 use std::io::Write;
 
+/// Strip the `/len` suffix from a CIDR string, returning the bare network address.
+fn to_bare_addr(s: String) -> String {
+    match s.split_once('/') {
+        Some((addr, _)) => addr.to_owned(),
+        None => s,
+    }
+}
+
+/// Format a prefix string, optionally stripping the `/len` suffix.
+fn format_key(s: String, bare: bool) -> String {
+    if bare { to_bare_addr(s) } else { s }
+}
+
 /// Find the closest covering prefix (immediate parent) for `prefix`.
 /// Uses `.last()` on cover_keys — DoubleEndedIterator is unavailable so .rev() cannot be used.
-fn find_parent<P, T>(map: &PrefixMap<P, T>, prefix: &P) -> Option<String>
+fn find_parent<P, T>(map: &PrefixMap<P, T>, prefix: &P, bare: bool) -> Option<String>
 where
     P: Prefix + PartialEq + std::fmt::Display,
 {
     map.cover_keys(prefix)
         .filter(|p| *p != prefix)
         .last()
-        .map(|p| p.to_string())
+        .map(|p| format_key(p.to_string(), bare))
 }
 
 /// Collect all stored prefixes more specific than `prefix` (self excluded).
-fn find_children<P, T>(map: &PrefixMap<P, T>, prefix: &P) -> Vec<String>
+fn find_children<P, T>(map: &PrefixMap<P, T>, prefix: &P, bare: bool) -> Vec<String>
 where
     P: Prefix + PartialEq + std::fmt::Display,
 {
     map.children(prefix)
         .filter(|(p, _)| *p != prefix)
-        .map(|(p, _)| p.to_string())
+        .map(|(p, _)| format_key(p.to_string(), bare))
         .collect()
 }
 
@@ -36,13 +49,14 @@ fn collect_values<P: Prefix>(map: &PrefixMap<P, Py<PyAny>>, py: Python<'_>) -> V
 }
 
 /// Collect all stored (prefix, value) pairs as Python tuples in trie traversal order.
-fn collect_items<P>(map: &PrefixMap<P, Py<PyAny>>, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>>
+fn collect_items<P>(map: &PrefixMap<P, Py<PyAny>>, py: Python<'_>, bare: bool) -> PyResult<Vec<Py<PyAny>>>
 where
     P: Prefix + std::fmt::Display,
 {
     map.iter().map(|(p, v)| {
+        let key_str = format_key(p.to_string(), bare);
         PyTuple::new(py, [
-            PyString::new(py, &p.to_string()).into_any().unbind(),
+            PyString::new(py, &key_str).into_any().unbind(),
             v.clone_ref(py),
         ]).map(|t| t.into_any().unbind())
     }).collect()
@@ -454,17 +468,18 @@ impl Pattrie {
         Ok(result.unwrap_or_else(|| default.unwrap_or_else(|| py.None())))
     }
 
-    fn get_key(&self, _py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Option<String>> {
+    #[pyo3(signature = (key, bare=false))]
+    fn get_key(&self, _py: Python<'_>, key: &Bound<'_, PyAny>, bare: bool) -> PyResult<Option<String>> {
         let af_inet = self.af_inet;
         let net = parse_key(_py, key, self.family, af_inet)?;
 
         let guard = self.inner.read().unwrap();
         Ok(match (&*guard, &net) {
             (TrieInner::V4(map), IpNet::V4(v4)) => {
-                map.get_lpm(v4).map(|(prefix, _)| prefix.to_string())
+                map.get_lpm(v4).map(|(prefix, _)| format_key(prefix.to_string(), bare))
             }
             (TrieInner::V6(map), IpNet::V6(v6)) => {
-                map.get_lpm(v6).map(|(prefix, _)| prefix.to_string())
+                map.get_lpm(v6).map(|(prefix, _)| format_key(prefix.to_string(), bare))
             }
             _ => None,
         })
@@ -726,16 +741,17 @@ impl Pattrie {
     }
 
     fn __iter__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
-        let keys = self.keys();
+        let keys = self.keys(false);
         let list = pyo3::types::PyList::new(py, &keys)?;
         Ok(list.call_method0("__iter__")?.unbind())
     }
 
-    fn keys(&self) -> Vec<String> {
+    #[pyo3(signature = (bare=false))]
+    fn keys(&self, bare: bool) -> Vec<String> {
         let guard = self.inner.read().unwrap();
         match &*guard {
-            TrieInner::V4(map) => map.iter().map(|(p, _)| p.to_string()).collect(),
-            TrieInner::V6(map) => map.iter().map(|(p, _)| p.to_string()).collect(),
+            TrieInner::V4(map) => map.iter().map(|(p, _)| format_key(p.to_string(), bare)).collect(),
+            TrieInner::V6(map) => map.iter().map(|(p, _)| format_key(p.to_string(), bare)).collect(),
         }
     }
 
@@ -747,34 +763,37 @@ impl Pattrie {
         }
     }
 
-    fn items(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
+    #[pyo3(signature = (bare=false))]
+    fn items(&self, py: Python<'_>, bare: bool) -> PyResult<Vec<Py<PyAny>>> {
         let guard = self.inner.read().unwrap();
         Ok(match &*guard {
-            TrieInner::V4(map) => collect_items(map, py)?,
-            TrieInner::V6(map) => collect_items(map, py)?,
+            TrieInner::V4(map) => collect_items(map, py, bare)?,
+            TrieInner::V6(map) => collect_items(map, py, bare)?,
         })
     }
 
-    fn children(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
+    #[pyo3(signature = (prefix, bare=false))]
+    fn children(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>, bare: bool) -> PyResult<Vec<String>> {
         let af_inet = self.af_inet;
         let net = parse_network_key(py, prefix, self.family, af_inet)?;
 
         let guard = self.inner.read().unwrap();
         Ok(match (&*guard, net) {
-            (TrieInner::V4(map), IpNet::V4(v4)) => find_children(map, &v4),
-            (TrieInner::V6(map), IpNet::V6(v6)) => find_children(map, &v6),
+            (TrieInner::V4(map), IpNet::V4(v4)) => find_children(map, &v4, bare),
+            (TrieInner::V6(map), IpNet::V6(v6)) => find_children(map, &v6, bare),
             _ => unreachable!(),
         })
     }
 
-    fn parent(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>) -> PyResult<Option<String>> {
+    #[pyo3(signature = (prefix, bare=false))]
+    fn parent(&self, py: Python<'_>, prefix: &Bound<'_, PyAny>, bare: bool) -> PyResult<Option<String>> {
         let af_inet = self.af_inet;
         let net = parse_network_key(py, prefix, self.family, af_inet)?;
 
         let guard = self.inner.read().unwrap();
         Ok(match (&*guard, net) {
-            (TrieInner::V4(map), IpNet::V4(v4)) => find_parent(map, &v4),
-            (TrieInner::V6(map), IpNet::V6(v6)) => find_parent(map, &v6),
+            (TrieInner::V4(map), IpNet::V4(v4)) => find_parent(map, &v4, bare),
+            (TrieInner::V6(map), IpNet::V6(v6)) => find_parent(map, &v6, bare),
             _ => unreachable!(),
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,38 +8,38 @@ use std::sync::{Arc, RwLock};
 use std::io::Write;
 
 /// Strip the `/len` suffix from a CIDR string, returning the bare network address.
-fn to_bare_addr(s: String) -> String {
+fn to_bare_addr(s: &str) -> String {
     match s.split_once('/') {
         Some((addr, _)) => addr.to_owned(),
-        None => s,
+        None => s.to_owned(),
     }
 }
 
 /// Format a prefix string, optionally stripping the `/len` suffix.
-fn format_key(s: String, bare: bool) -> String {
-    if bare { to_bare_addr(s) } else { s }
+fn format_key(s: &str, bare: bool) -> String {
+    if bare { to_bare_addr(s) } else { s.to_owned() }
 }
 
 /// Find the closest covering prefix (immediate parent) for `prefix`.
 /// Uses `.last()` on cover_keys — DoubleEndedIterator is unavailable so .rev() cannot be used.
-fn find_parent<P, T>(map: &PrefixMap<P, T>, prefix: &P, bare: bool) -> Option<String>
+fn find_parent<P, T>(map: &PrefixMap<P, T>, prefix: &P) -> Option<String>
 where
     P: Prefix + PartialEq + std::fmt::Display,
 {
     map.cover_keys(prefix)
         .filter(|p| *p != prefix)
         .last()
-        .map(|p| format_key(p.to_string(), bare))
+        .map(|p| p.to_string())
 }
 
 /// Collect all stored prefixes more specific than `prefix` (self excluded).
-fn find_children<P, T>(map: &PrefixMap<P, T>, prefix: &P, bare: bool) -> Vec<String>
+fn find_children<P, T>(map: &PrefixMap<P, T>, prefix: &P) -> Vec<String>
 where
     P: Prefix + PartialEq + std::fmt::Display,
 {
     map.children(prefix)
         .filter(|(p, _)| *p != prefix)
-        .map(|(p, _)| format_key(p.to_string(), bare))
+        .map(|(p, _)| p.to_string())
         .collect()
 }
 
@@ -48,18 +48,12 @@ fn collect_values<P: Prefix>(map: &PrefixMap<P, Py<PyAny>>, py: Python<'_>) -> V
     map.iter().map(|(_, v)| v.clone_ref(py)).collect()
 }
 
-/// Collect all stored (prefix, value) pairs as Python tuples in trie traversal order.
-fn collect_items<P>(map: &PrefixMap<P, Py<PyAny>>, py: Python<'_>, bare: bool) -> PyResult<Vec<Py<PyAny>>>
+/// Collect all stored (prefix, value) pairs in trie traversal order.
+fn collect_items<P>(map: &PrefixMap<P, Py<PyAny>>, py: Python<'_>) -> Vec<(String, Py<PyAny>)>
 where
     P: Prefix + std::fmt::Display,
 {
-    map.iter().map(|(p, v)| {
-        let key_str = format_key(p.to_string(), bare);
-        PyTuple::new(py, [
-            PyString::new(py, &key_str).into_any().unbind(),
-            v.clone_ref(py),
-        ]).map(|t| t.into_any().unbind())
-    }).collect()
+    map.iter().map(|(p, v)| (p.to_string(), v.clone_ref(py))).collect()
 }
 
 /// Collect all stored (prefix, value) covering pairs for `prefix`,
@@ -474,15 +468,12 @@ impl Pattrie {
         let net = parse_key(_py, key, self.family, af_inet)?;
 
         let guard = self.inner.read().unwrap();
-        Ok(match (&*guard, &net) {
-            (TrieInner::V4(map), IpNet::V4(v4)) => {
-                map.get_lpm(v4).map(|(prefix, _)| format_key(prefix.to_string(), bare))
-            }
-            (TrieInner::V6(map), IpNet::V6(v6)) => {
-                map.get_lpm(v6).map(|(prefix, _)| format_key(prefix.to_string(), bare))
-            }
+        let full = match (&*guard, &net) {
+            (TrieInner::V4(map), IpNet::V4(v4)) => map.get_lpm(v4).map(|(p, _)| p.to_string()),
+            (TrieInner::V6(map), IpNet::V6(v6)) => map.get_lpm(v6).map(|(p, _)| p.to_string()),
             _ => None,
-        })
+        };
+        Ok(full.map(|s| format_key(&s, bare)))
     }
 
     fn __delitem__(&mut self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<()> {
@@ -749,10 +740,11 @@ impl Pattrie {
     #[pyo3(signature = (bare=false))]
     fn keys(&self, bare: bool) -> Vec<String> {
         let guard = self.inner.read().unwrap();
-        match &*guard {
-            TrieInner::V4(map) => map.iter().map(|(p, _)| format_key(p.to_string(), bare)).collect(),
-            TrieInner::V6(map) => map.iter().map(|(p, _)| format_key(p.to_string(), bare)).collect(),
-        }
+        let full: Vec<String> = match &*guard {
+            TrieInner::V4(map) => map.iter().map(|(p, _)| p.to_string()).collect(),
+            TrieInner::V6(map) => map.iter().map(|(p, _)| p.to_string()).collect(),
+        };
+        if bare { full.iter().map(|s| to_bare_addr(s)).collect() } else { full }
     }
 
     fn values(&self, py: Python<'_>) -> Vec<Py<PyAny>> {
@@ -766,10 +758,15 @@ impl Pattrie {
     #[pyo3(signature = (bare=false))]
     fn items(&self, py: Python<'_>, bare: bool) -> PyResult<Vec<Py<PyAny>>> {
         let guard = self.inner.read().unwrap();
-        Ok(match &*guard {
-            TrieInner::V4(map) => collect_items(map, py, bare)?,
-            TrieInner::V6(map) => collect_items(map, py, bare)?,
-        })
+        let pairs = match &*guard {
+            TrieInner::V4(map) => collect_items(map, py),
+            TrieInner::V6(map) => collect_items(map, py),
+        };
+        pairs.into_iter().map(|(k, v)| {
+            let key_str = format_key(&k, bare);
+            PyTuple::new(py, [PyString::new(py, &key_str).into_any().unbind(), v])
+                .map(|t| t.into_any().unbind())
+        }).collect()
     }
 
     #[pyo3(signature = (prefix, bare=false))]
@@ -778,11 +775,12 @@ impl Pattrie {
         let net = parse_network_key(py, prefix, self.family, af_inet)?;
 
         let guard = self.inner.read().unwrap();
-        Ok(match (&*guard, net) {
-            (TrieInner::V4(map), IpNet::V4(v4)) => find_children(map, &v4, bare),
-            (TrieInner::V6(map), IpNet::V6(v6)) => find_children(map, &v6, bare),
+        let full = match (&*guard, net) {
+            (TrieInner::V4(map), IpNet::V4(v4)) => find_children(map, &v4),
+            (TrieInner::V6(map), IpNet::V6(v6)) => find_children(map, &v6),
             _ => unreachable!(),
-        })
+        };
+        Ok(if bare { full.iter().map(|s| to_bare_addr(s)).collect() } else { full })
     }
 
     #[pyo3(signature = (prefix, bare=false))]
@@ -791,11 +789,12 @@ impl Pattrie {
         let net = parse_network_key(py, prefix, self.family, af_inet)?;
 
         let guard = self.inner.read().unwrap();
-        Ok(match (&*guard, net) {
-            (TrieInner::V4(map), IpNet::V4(v4)) => find_parent(map, &v4, bare),
-            (TrieInner::V6(map), IpNet::V6(v6)) => find_parent(map, &v6, bare),
+        let full = match (&*guard, net) {
+            (TrieInner::V4(map), IpNet::V4(v4)) => find_parent(map, &v4),
+            (TrieInner::V6(map), IpNet::V6(v6)) => find_parent(map, &v6),
             _ => unreachable!(),
-        })
+        };
+        Ok(full.map(|s| format_key(&s, bare)))
     }
 
     fn get_all(&self, py: Python<'_>, key: &Bound<'_, PyAny>) -> PyResult<Vec<Py<PyAny>>> {

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -1759,6 +1759,7 @@ def test_eq_ipv6_same_entries():
 # bare=True tests (issue #45)
 # ---------------------------------------------------------------------------
 
+
 def test_keys_default_cidr():
     t = pattrie.Pattrie()
     t["10.1.0.0/24"] = "a"

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -1753,3 +1753,132 @@ def test_eq_ipv6_same_entries():
     t2 = pattrie.Pattrie(128, socket.AF_INET6)
     t2["2001:db8::/32"] = "a"
     assert t1 == t2
+
+
+# ---------------------------------------------------------------------------
+# bare=True tests (issue #45)
+# ---------------------------------------------------------------------------
+
+def test_keys_default_cidr():
+    t = pattrie.Pattrie()
+    t["10.1.0.0/24"] = "a"
+    t["10.2.0.0/16"] = "b"
+    assert t.keys() == ["10.1.0.0/24", "10.2.0.0/16"]
+
+
+def test_keys_bare_ipv4():
+    t = pattrie.Pattrie()
+    t["10.1.0.0/24"] = "a"
+    t["10.2.0.0/16"] = "b"
+    assert t.keys(bare=True) == ["10.1.0.0", "10.2.0.0"]
+
+
+def test_keys_bare_ipv4_host_route():
+    t = pattrie.Pattrie()
+    t["10.1.2.3/32"] = "a"
+    assert t.keys(bare=True) == ["10.1.2.3"]
+
+
+def test_keys_bare_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "a"
+    t["2001:db8:1::/48"] = "b"
+    assert t.keys(bare=True) == ["2001:db8::", "2001:db8:1::"]
+
+
+def test_keys_bare_ipv6_host_route():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::1/128"] = "a"
+    assert t.keys(bare=True) == ["2001:db8::1"]
+
+
+def test_items_default_cidr():
+    t = pattrie.Pattrie()
+    t["10.1.0.0/24"] = "a"
+    assert t.items() == [("10.1.0.0/24", "a")]
+
+
+def test_items_bare_ipv4():
+    t = pattrie.Pattrie()
+    t["10.1.0.0/24"] = "a"
+    t["10.2.0.0/16"] = "b"
+    assert t.items(bare=True) == [("10.1.0.0", "a"), ("10.2.0.0", "b")]
+
+
+def test_items_bare_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "x"
+    assert t.items(bare=True) == [("2001:db8::", "x")]
+
+
+def test_children_default_cidr():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    t["10.2.0.0/16"] = "c"
+    assert t.children("10.0.0.0/8") == ["10.1.0.0/16", "10.2.0.0/16"]
+
+
+def test_children_bare_ipv4():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    t["10.2.0.0/16"] = "c"
+    assert t.children("10.0.0.0/8", bare=True) == ["10.1.0.0", "10.2.0.0"]
+
+
+def test_children_bare_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "a"
+    t["2001:db8:1::/48"] = "b"
+    assert t.children("2001:db8::/32", bare=True) == ["2001:db8:1::"]
+
+
+def test_parent_default_cidr():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    assert t.parent("10.1.0.0/16") == "10.0.0.0/8"
+
+
+def test_parent_bare_ipv4():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.0.0/16"] = "b"
+    assert t.parent("10.1.0.0/16", bare=True) == "10.0.0.0"
+
+
+def test_parent_bare_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "a"
+    t["2001:db8:1::/48"] = "b"
+    assert t.parent("2001:db8:1::/48", bare=True) == "2001:db8::"
+
+
+def test_parent_bare_none_when_no_parent():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    assert t.parent("10.0.0.0/8", bare=True) is None
+
+
+def test_get_key_default_cidr():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    assert t.get_key("10.1.2.3") == "10.0.0.0/8"
+
+
+def test_get_key_bare_ipv4():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    assert t.get_key("10.1.2.3", bare=True) == "10.0.0.0"
+
+
+def test_get_key_bare_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "a"
+    assert t.get_key("2001:db8::1", bare=True) == "2001:db8::"
+
+
+def test_get_key_bare_none_on_miss():
+    t = pattrie.Pattrie()
+    assert t.get_key("10.1.2.3", bare=True) is None

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -1882,3 +1882,28 @@ def test_get_key_bare_ipv6():
 def test_get_key_bare_none_on_miss():
     t = pattrie.Pattrie()
     assert t.get_key("10.1.2.3", bare=True) is None
+
+
+def test_keys_bare_duplicate_when_same_network_address():
+    # Two prefixes sharing the same network address but different lengths
+    # produce duplicate bare keys — this is expected (documented) lossy behavior.
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.0.0.0/16"] = "b"
+    result = t.keys(bare=True)
+    assert result == ["10.0.0.0", "10.0.0.0"]
+
+
+def test_items_bare_duplicate_keys_dict_loses_entry():
+    # Documented: dict(items(bare=True)) silently drops the less-specific entry
+    # when two prefixes share the same network address.
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.0.0.0/16"] = "b"
+    pairs = t.items(bare=True)
+    assert len(pairs) == 2
+    assert pairs[0][0] == "10.0.0.0"
+    assert pairs[1][0] == "10.0.0.0"
+    # dict() collapses duplicates — the second value wins
+    d = dict(pairs)  # type: ignore[arg-type]
+    assert len(d) == 1

--- a/tests/test_pattrie.py
+++ b/tests/test_pattrie.py
@@ -1862,6 +1862,24 @@ def test_parent_bare_none_when_no_parent():
     assert t.parent("10.0.0.0/8", bare=True) is None
 
 
+def test_parent_host_route_ipv4():
+    t = pattrie.Pattrie()
+    t["10.0.0.0/8"] = "a"
+    t["10.1.2.0/24"] = "b"
+    t["10.1.2.3/32"] = "c"
+    assert t.parent("10.1.2.3/32") == "10.1.2.0/24"
+    assert t.parent("10.1.2.3/32", bare=True) == "10.1.2.0"
+
+
+def test_parent_host_route_ipv6():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::/32"] = "a"
+    t["2001:db8:1::/64"] = "b"
+    t["2001:db8:1::1/128"] = "c"
+    assert t.parent("2001:db8:1::1/128") == "2001:db8:1::/64"
+    assert t.parent("2001:db8:1::1/128", bare=True) == "2001:db8:1::"
+
+
 def test_get_key_default_cidr():
     t = pattrie.Pattrie()
     t["10.0.0.0/8"] = "a"
@@ -1878,6 +1896,18 @@ def test_get_key_bare_ipv6():
     t = pattrie.Pattrie(128, socket.AF_INET6)
     t["2001:db8::/32"] = "a"
     assert t.get_key("2001:db8::1", bare=True) == "2001:db8::"
+
+
+def test_get_key_bare_ipv4_host_route():
+    t = pattrie.Pattrie()
+    t["10.1.2.3/32"] = "a"
+    assert t.get_key("10.1.2.3", bare=True) == "10.1.2.3"
+
+
+def test_get_key_bare_ipv6_host_route():
+    t = pattrie.Pattrie(128, socket.AF_INET6)
+    t["2001:db8::1/128"] = "a"
+    assert t.get_key("2001:db8::1", bare=True) == "2001:db8::1"
 
 
 def test_get_key_bare_none_on_miss():
@@ -1905,6 +1935,7 @@ def test_items_bare_duplicate_keys_dict_loses_entry():
     assert len(pairs) == 2
     assert pairs[0][0] == "10.0.0.0"
     assert pairs[1][0] == "10.0.0.0"
-    # dict() collapses duplicates — the second value wins
+    # dict() collapses duplicates — the more-specific (/16) entry is last and wins
     d = dict(pairs)  # type: ignore[arg-type]
     assert len(d) == 1
+    assert d["10.0.0.0"] == "b"


### PR DESCRIPTION
Adds an opt-in bare=False parameter to keys(), items(), children(),
parent(), and get_key(). When bare=True the /len suffix is stripped,
returning only the bare network address (e.g. "10.1.0.0" instead of
"10.1.0.0/24"). Default behaviour is unchanged.
