### PR TITLE
fix(ci): install Python interpreters for all wheel build targets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ jobs:
   build-wheels:
     name: Wheels / ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    env:
+      INTERPRETERS: -i python3.12 python3.13 python3.14
     strategy:
       matrix:
         include:
@@ -16,37 +18,37 @@ jobs:
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             manylinux: auto
-            extra_args: -i python3.12 python3.13 python3.14
+            extra_args: ''
           # Linux x86_64 — musl (Alpine Docker)
           - name: linux-x86_64-musl
             os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             manylinux: musllinux_1_2
-            extra_args: --zig -i python3.12 python3.13 python3.14
+            extra_args: --zig
           # Linux aarch64 — glibc (AWS Graviton, Docker on Apple Silicon)
           - name: linux-aarch64
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             manylinux: manylinux_2_28
-            extra_args: --zig -i python3.12 python3.13 python3.14
+            extra_args: --zig
           # Linux aarch64 — musl (Alpine Docker on ARM)
           - name: linux-aarch64-musl
             os: ubuntu-latest
             target: aarch64-unknown-linux-musl
             manylinux: musllinux_1_2
-            extra_args: --zig -i python3.12 python3.13 python3.14
+            extra_args: --zig
           # macOS universal2 — fat binary covering both Intel and Apple Silicon
           - name: macos-universal2
             os: macos-latest
             target: universal2-apple-darwin
             manylinux: auto
-            extra_args: -i python3.12 python3.13 python3.14
+            extra_args: ''
           # Windows x86_64
           - name: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
             manylinux: auto
-            extra_args: -i python3.12 python3.13 python3.14
+            extra_args: ''
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -65,7 +67,7 @@ jobs:
         with:
           command: build
           target: ${{ matrix.target }}
-          args: --release --out dist ${{ matrix.extra_args }}
+          args: --release --out dist ${{ env.INTERPRETERS }} ${{ matrix.extra_args }}
           manylinux: ${{ matrix.manylinux }}
       - uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             manylinux: auto
-            extra_args: ''
+            extra_args: -i python3.12 python3.13 python3.14
           # Linux x86_64 — musl (Alpine Docker)
           - name: linux-x86_64-musl
             os: ubuntu-latest
@@ -40,17 +40,16 @@ jobs:
             os: macos-latest
             target: universal2-apple-darwin
             manylinux: auto
-            extra_args: ''
+            extra_args: -i python3.12 python3.13 python3.14
           # Windows x86_64
           - name: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
             manylinux: auto
-            extra_args: ''
+            extra_args: -i python3.12 python3.13 python3.14
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
-        if: contains(matrix.extra_args, '--zig')
         with:
           python-version: |
             3.12


### PR DESCRIPTION
The setup-python step was gated to only run for --zig builds, leaving
the glibc, macOS, and Windows targets without any interpreter. maturin
then failed searching PATH for python3. Ungate setup-python and add
explicit -i interpreter lists so every target builds wheels for
Python 3.12-3.14.
